### PR TITLE
Improve appearance of vector markers.

### DIFF
--- a/src/java/uk/ac/rdg/resc/ncwms/controller/AbstractWmsController.java
+++ b/src/java/uk/ac/rdg/resc/ncwms/controller/AbstractWmsController.java
@@ -457,7 +457,8 @@ public abstract class AbstractWmsController extends AbstractController {
             else if (styleType.equalsIgnoreCase("fancyvec")) style = ImageProducer.Style.FANCYVEC;
             else if (styleType.equalsIgnoreCase("linevec")) style = ImageProducer.Style.LINEVEC;
             else if (styleType.equalsIgnoreCase("stumpvec")) style = ImageProducer.Style.STUMPVEC;
-            else if (styleType.equalsIgnoreCase("trivec")) style = ImageProducer.Style.TRIVEC;           
+            else if (styleType.equalsIgnoreCase("trivec")) style = ImageProducer.Style.TRIVEC;
+            else if (styleType.equalsIgnoreCase("prettyvec")) style = ImageProducer.Style.PRETTYVEC;
             else throw new StyleNotDefinedException("The style " + styles[0] +
                 " is not supported by this server");
 
@@ -485,6 +486,7 @@ public abstract class AbstractWmsController extends AbstractController {
             .opacity(styleRequest.getOpacity())
             .numColourBands(styleRequest.getNumColourBands())
             .numContours(styleRequest.getNumContours())
+            .vectorScale(styleRequest.getVectorScaleFactor())
             .build();
         // Need to make sure that the images will be compatible with the
         // requested image format

--- a/src/java/uk/ac/rdg/resc/ncwms/controller/GetMapStyleRequest.java
+++ b/src/java/uk/ac/rdg/resc/ncwms/controller/GetMapStyleRequest.java
@@ -58,6 +58,7 @@ public class GetMapStyleRequest
     private Range<Float> colorScaleRange;
     private Color highColor;
     private Color lowColor;
+    private float vectorScaleFactor;
     
     /**
      * Creates a new instance of GetMapStyleRequest from the given parameters
@@ -130,6 +131,7 @@ public class GetMapStyleRequest
         this.numColourBands = getNumColourBands(params);
         this.numContours = getNumContours(params);
         this.logarithmic = isLogScale(params);
+        this.vectorScaleFactor = params.getFloat("vectorScaleFactor", 1.0f);
     }
     
     /**
@@ -283,5 +285,9 @@ public class GetMapStyleRequest
     
     public int getNumContours() {
         return numContours;
+    }
+    
+    public float getVectorScaleFactor() {
+        return vectorScaleFactor;
     }
 }

--- a/src/java/uk/ac/rdg/resc/ncwms/graphics/ImageProducer.java
+++ b/src/java/uk/ac/rdg/resc/ncwms/graphics/ImageProducer.java
@@ -78,7 +78,7 @@ public final class ImageProducer
     private static final Logger logger = LoggerFactory.getLogger(ImageProducer.class);
 
     //public static enum Style {BOXFILL, VECTOR, CONTOUR, BARB, ARROWS};
-    public static enum Style {BOXFILL, VECTOR, CONTOUR, BARB, STUMPVEC, TRIVEC, LINEVEC, FANCYVEC};
+    public static enum Style {BOXFILL, VECTOR, CONTOUR, BARB, STUMPVEC, TRIVEC, LINEVEC, FANCYVEC, PRETTYVEC};
     
     private Style style;
     // Width and height of the resulting picture
@@ -253,7 +253,7 @@ public final class ImageProducer
 
         if (style == Style.VECTOR || isArrowStyle(style) || style == Style.BARB) {
             Graphics2D g = image.createGraphics();
-            g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_OFF);
+            g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
             g.setColor(new Color(0, 0, 0));
 
             float stepScale = 1.1f;
@@ -519,8 +519,7 @@ public final class ImageProducer
     }
     
     private boolean isArrowStyle(Style style){
-    	
-    	return style == Style.BARB || style == Style.FANCYVEC || style == Style.STUMPVEC || style == Style.TRIVEC || style == Style.LINEVEC;
+        return style == Style.BARB || style == Style.FANCYVEC || style == Style.STUMPVEC || style == Style.TRIVEC || style == Style.LINEVEC || style == Style.PRETTYVEC;
     }
 
     public int getOpacity()

--- a/src/java/uk/ac/rdg/resc/ncwms/graphics/VectorFactory.java
+++ b/src/java/uk/ac/rdg/resc/ncwms/graphics/VectorFactory.java
@@ -48,6 +48,7 @@ public class VectorFactory {
         vectors.add(triangleVector());
         vectors.add(lineVector());
         vectors.add(fancyVector());
+        vectors.add(prettyVector());
     }
 
     public VectorFactory() {
@@ -56,7 +57,7 @@ public class VectorFactory {
     public static void renderVector(String style, double speed, double angle, int i, int j,
             float scale, Graphics2D g) {
 
-        int type = 0;
+        int type = 4;
         if (style.equalsIgnoreCase("STUMPVEC")) {
             type = 0;
         } else if (style.equalsIgnoreCase("TRIVEC")) {
@@ -65,6 +66,8 @@ public class VectorFactory {
             type = 2;
         } else if (style.equalsIgnoreCase("FANCYVEC")) {
             type = 3;
+        } else if (style.equalsIgnoreCase("PRETTYVEC")) {
+            type = 4;
         }
 
         Path2D ret = (Path2D) vectors.get(type).clone();
@@ -74,10 +77,7 @@ public class VectorFactory {
         ret.transform(AffineTransform.getScaleInstance(scale, scale));
         ret.transform(AffineTransform.getTranslateInstance(i, j));
 
-        // Don't fill the FANCYVEC
-        if (type != 3) {
-            g.fill(ret);
-        }
+        g.fill(ret);
         g.draw(ret);
     }
 
@@ -124,6 +124,19 @@ public class VectorFactory {
         path.lineTo(11, -1.5);
         path.lineTo(3, 2);
         path.lineTo(5, -1);
+        path.closePath();
+        return path;
+    }
+    
+    private static Path2D prettyVector() {
+        Path2D path = new Path2D.Double();
+        path.moveTo(0, -0.5);
+        path.lineTo(7.5, -0.5);
+        path.lineTo(6, -2.5);
+        path.lineTo(12, 0);
+        path.lineTo(6, 2.5);
+        path.lineTo(7.5, 0.5);
+        path.lineTo(0, 0.5);
         path.closePath();
         return path;
     }

--- a/web/WEB-INF/jsp/capabilities_xml.jsp
+++ b/web/WEB-INF/jsp/capabilities_xml.jsp
@@ -131,7 +131,7 @@ response.setDateHeader ("Expires", 0); //prevents caching at the proxy server
                     </c:if>
                     <c:set var="styles" value="boxfill"/>
                     <c:if test="${utils:isVectorLayer(layer)}">
-                        <c:set var="styles" value="barb,fancyvec,trivec,stumpvec,linevec,vector,boxfill"/>
+                        <c:set var="styles" value="barb,prettyvec,fancyvec,trivec,stumpvec,linevec,vector,boxfill"/>
                     </c:if>
                     <c:forEach var="style" items="${styles}">
                     <c:forEach var="paletteName" items="${paletteNames}">

--- a/web/WEB-INF/jsp/capabilities_xml_1_1_1.jsp
+++ b/web/WEB-INF/jsp/capabilities_xml_1_1_1.jsp
@@ -150,7 +150,7 @@ response.setDateHeader ("Expires", 0); //prevents caching at the proxy server
                     </c:if>
                     <c:set var="styles" value="boxfill"/>
                     <c:if test="${utils:isVectorLayer(layer)}">
-                        <c:set var="styles" value="barb,fancyvec,trivec,stumpvec,linevec,vector,boxfill"/>
+                        <c:set var="styles" value="barb,prettyvec,fancyvec,trivec,stumpvec,linevec,vector,boxfill"/>
                     </c:if>
                     <c:forEach var="style" items="${styles}">
                     <c:forEach var="paletteName" items="${paletteNames}">

--- a/web/WEB-INF/jsp/showLayerDetails.jsp
+++ b/web/WEB-INF/jsp/showLayerDetails.jsp
@@ -40,7 +40,7 @@ response.setDateHeader ("Expires", 0); //prevents caching at the proxy server
 
     <c:set var="styles" value="boxfill,contour"/>
     <c:if test="${utils:isVectorLayer(layer)}">
-        <c:set var="styles" value="vector,arrows,boxfill,contour"/>
+        <c:set var="styles" value="barb,prettyvec,fancyvec,trivec,stumpvec,linevec,vector,boxfill"/>
     </c:if>
     <json:array name="supportedStyles" items="${styles}"/>
 


### PR DESCRIPTION
None of the current vector marker styles resembles a standard vector marker
as found in other scientific plotting applications. In addition, due to the
small size of the vector markers, they tend to clutter the image too much
and the direction might not be easy to grasp.

The `ImageProducer` class already has an option to control the size of the
vectors, whose value is 1 by default, and which scales the marker by that
factor in both directions. The spacing between vectors is adjusted so that
origins of vectors are not overlapped.

So this request proposes a new style parameter `vectorScaleFactor`,
directly mapped to that factor, and a new a vector style `prettyvec`
with a standard arrow shape:

  * Add `prettyvec` vector style to display pretty vector markers,

  * Expose the vector scale factor option as a style parameter
     to control the density of vector markers in the rendered image.

  * Change vector marker for style `vector` (vectors above pseudocolor-map)
    from `stumpvec` to new `prettyvec`.

  * Fill vectors in `fancyvec` style, as done in all other vector styles.

  * Fix listing of vector styles in jsp files.

The results can be tested at SOCIB's web map viewer
(layer parameters are on the Style Selection panel on the top right corner):
  http://thredds.socib.es/lw4nc2/?m=satwind&i18n=en_EN

![screenshot](https://cloud.githubusercontent.com/assets/3691987/4186327/d75629fe-375f-11e4-8456-edd344ee2fd6.png)
