### PR TITLE
Add support for colors with transparency in palettes and legend.

### DIFF
--- a/src/java/uk/ac/rdg/resc/ncwms/controller/AbstractWmsController.java
+++ b/src/java/uk/ac/rdg/resc/ncwms/controller/AbstractWmsController.java
@@ -27,6 +27,7 @@
  */
 package uk.ac.rdg.resc.ncwms.controller;
 
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -760,9 +761,13 @@ public abstract class AbstractWmsController extends AbstractController {
                     + "the scale extremes explicitly.");
             }
 
+            boolean transparent = params.getBoolean("transparent", false);
+            Color backgroundColor = params.getColor("bgcolor", Color.black);
+
             // Now create the legend image
-            legend = palette.createLegend(numColourBands, layer.getTitle(),
-                    layer.getUnits(), logarithmic, colorScaleRange);
+            legend = palette.createLegend(numColourBands, layer.getTitle(), layer.getUnits(),
+                                          logarithmic, colorScaleRange,
+                                          transparent, backgroundColor);
         }
         httpServletResponse.setContentType("image/png");
         ImageIO.write(legend, "png", httpServletResponse.getOutputStream());

--- a/src/java/uk/ac/rdg/resc/ncwms/controller/GetMapStyleRequest.java
+++ b/src/java/uk/ac/rdg/resc/ncwms/controller/GetMapStyleRequest.java
@@ -75,51 +75,39 @@ public class GetMapStyleRequest
 
         this.transparent = params.getBoolean("transparent", false);
         
-        try
-        {
-            String bgc = params.getString("bgcolor", "0xFFFFFF");
-            if (bgc.length() != 8 || !bgc.startsWith("0x")) throw new Exception();
-            // Parse the hexadecimal string, ignoring the "0x" prefix
-            this.backgroundColour = new Color(Integer.parseInt(bgc.substring(2), 16));
-        }
-        catch(Exception e)
-        {
+        try {
+            this.backgroundColour = params.getColor("bgcolor", Color.black);
+        } catch(Exception e) {
             throw new WmsException("Invalid format for BGCOLOR");
         }
         
         String lowColorStr = params.getString("belowmincolor");
         if(lowColorStr == null) {
-            lowColor = Color.black;
+            this.lowColor = Color.black;
         } else if(lowColorStr.equalsIgnoreCase("extend")) {
-            lowColor = null;
+            this.lowColor = null;
         } else if(lowColorStr.equalsIgnoreCase("transparent")) {
-            lowColor = new Color(0, 0, 0, 0);
+            this.lowColor = new Color(0, 0, 0, 0);
         } else {
             try {
-                if (lowColorStr.length() != 8 || !lowColorStr.startsWith("0x"))
-                    throw new Exception();
-                // Parse the hexadecimal string, ignoring the "0x" prefix
-                lowColor= new Color(Integer.parseInt(lowColorStr.substring(2), 16));
+                this.lowColor = params.getColor("belowmincolor", Color.black);
             } catch (Exception e) {
-                throw new WmsException("Invalid format for BELOWMINCOLOR");
+                throw new WmsException("Invalid format for BELOWMINCOLOR: " + e.getMessage());
             }
         }
         
         String highColorStr = params.getString("abovemaxcolor");
         if(highColorStr == null) {
-            highColor = Color.black;
+            this.highColor = Color.black;
         } else if(highColorStr.equalsIgnoreCase("extend")) {
-            highColor = null;
+            this.highColor = null;
         } else if(highColorStr.equalsIgnoreCase("transparent")) {
-            highColor = new Color(0, 0, 0, 0);
+            this.highColor = new Color(0, 0, 0, 0);
         } else {
             try {
-                if (highColorStr.length() != 8 || !highColorStr.startsWith("0x"))
-                    throw new Exception();
-                // Parse the hexadecimal string, ignoring the "0x" prefix
-                highColor = new Color(Integer.parseInt(highColorStr.substring(2), 16));
+                this.highColor = params.getColor("abovemaxcolor", Color.black);
             } catch (Exception e) {
-                throw new WmsException("Invalid format for ABOVEMAXCOLOR");
+                throw new WmsException("Invalid format for ABOVEMAXCOLOR: " + e.getMessage());
             }
         }
         

--- a/src/java/uk/ac/rdg/resc/ncwms/controller/RequestParams.java
+++ b/src/java/uk/ac/rdg/resc/ncwms/controller/RequestParams.java
@@ -28,6 +28,7 @@
 
 package uk.ac.rdg.resc.ncwms.controller;
 
+import java.awt.Color;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.HashMap;
@@ -230,4 +231,21 @@ public class RequestParams
         }
     }
     
+    public Color getColor(String paramName, Color defaultValue) throws WmsException
+    {
+       String value = this.getString(paramName);
+       if (value == null)
+       {
+           return defaultValue;
+       }
+       try
+       {
+           return Color.decode(value);
+       }
+       catch(NumberFormatException nfe)
+       {
+           throw new WmsException("Parameter " + paramName.toUpperCase() +
+               " must be a valid color code (0xXXXXXX or #000000).");
+       }
+    }
 }

--- a/src/java/uk/ac/rdg/resc/ncwms/graphics/ImageProducer.java
+++ b/src/java/uk/ac/rdg/resc/ncwms/graphics/ImageProducer.java
@@ -139,7 +139,8 @@ public final class ImageProducer
     public BufferedImage getLegend(Layer layer)
     {
         return this.colorPalette.createLegend(this.numColourBands, layer.getTitle(),
-            layer.getUnits(), this.logarithmic, this.scaleRange);
+            layer.getUnits(), this.logarithmic, this.scaleRange,
+            this.transparent, this.bgColor);
     }
     
     public int getPicWidth()
@@ -286,7 +287,8 @@ public final class ImageProducer
                         // Color arrow
                         index = this.getColourIndex(mag.floatValue());
                         if (this.style != Style.VECTOR) {
-                            g.setColor(new Color(colorModel.getRGB(index)));
+                            g.setColor(new Color(colorModel.getRGB(index),
+                                                 colorModel.hasAlpha()));
                         }
                         if (this.style == Style.BARB) {
                             g.setStroke(new BasicStroke(1));
@@ -354,18 +356,6 @@ public final class ImageProducer
         Graphics2D g = image.createGraphics();
         renderer.draw(g);
         
-//        int transpPixel = getColorModel().getRGB(0);
-//        System.out.println(transpPixel);
-//        for(int i=0; i<image.getWidth();i++) {
-//            for(int j=0; j<image.getHeight();j++) {
-//                int rgb = image.getRGB(i, j);
-//                System.out.println("rgb:"+rgb);
-//                if(rgb == transpPixel) {
-//                    image.setRGB(i, j, 0);
-//                }
-//            }            
-//        }
-//        
         return image;
     }
 


### PR DESCRIPTION
Currently, palettes are composed of opaque colors only.
In addition the legend is always displayed with black background and white text.
It would be desirable to be able to request a legend with a custom background color or tranparent,
and also to specify colors with alpha values in the palettes.
This proposal introduces both improvements, with complete backwards compatibility:

  * Improve handling of color parameters in the requests.

  * Modify the color model generation to handle transparent colors.
    The alpha value of each color is scaled by the opacity value.

  * Modify the color palette reader to support alpha channel values
    in each color definition line (ARGB order). If a line has only
    three values (RGB order) the color is completely opaque,
    providing full compatibility with existing palettes without
    alpha values in their colors.

  * Add `transparent` and `bgcolor` parameters to the legend request
    to control the appearance of the background of the legend.
    This are the same parameters used in a `GetMap` request.
    They default to false and black, so the handling of the legend
    request is backwards compatible if the parameters are omitted.
