### PR TITLE
GetCapabilities and GetMetadata requests advertise same layer styles

### DIFF
--- a/web/WEB-INF/jsp/capabilities_xml.jsp
+++ b/web/WEB-INF/jsp/capabilities_xml.jsp
@@ -129,9 +129,9 @@ response.setDateHeader ("Expires", 0); //prevents caching at the proxy server
                             </c:choose>
                         </Dimension>
                     </c:if>
-                    <c:set var="styles" value="boxfill"/>
+                    <c:set var="styles" value="boxfill,contour"/>
                     <c:if test="${utils:isVectorLayer(layer)}">
-                        <c:set var="styles" value="barb,fancyvec,trivec,stumpvec,linevec,vector,boxfill"/>
+                        <c:set var="styles" value="barb,fancyvec,trivec,stumpvec,linevec,vector,arrows,boxfill,contour"/>
                     </c:if>
                     <c:forEach var="style" items="${styles}">
                     <c:forEach var="paletteName" items="${paletteNames}">

--- a/web/WEB-INF/jsp/capabilities_xml_1_1_1.jsp
+++ b/web/WEB-INF/jsp/capabilities_xml_1_1_1.jsp
@@ -148,9 +148,9 @@ response.setDateHeader ("Expires", 0); //prevents caching at the proxy server
                           </c:choose>
                       </Extent>
                     </c:if>
-                    <c:set var="styles" value="boxfill"/>
+                    <c:set var="styles" value="boxfill,contour"/>
                     <c:if test="${utils:isVectorLayer(layer)}">
-                        <c:set var="styles" value="barb,fancyvec,trivec,stumpvec,linevec,vector,boxfill"/>
+                        <c:set var="styles" value="barb,fancyvec,trivec,stumpvec,linevec,vector,arrows,boxfill,contour"/>
                     </c:if>
                     <c:forEach var="style" items="${styles}">
                     <c:forEach var="paletteName" items="${paletteNames}">

--- a/web/WEB-INF/jsp/showLayerDetails.jsp
+++ b/web/WEB-INF/jsp/showLayerDetails.jsp
@@ -40,7 +40,7 @@ response.setDateHeader ("Expires", 0); //prevents caching at the proxy server
 
     <c:set var="styles" value="boxfill,contour"/>
     <c:if test="${utils:isVectorLayer(layer)}">
-        <c:set var="styles" value="vector,arrows,boxfill,contour"/>
+        <c:set var="styles" value="barb,fancyvec,trivec,stumpvec,linevec,vector,arrows,boxfill,contour"/>
     </c:if>
     <json:array name="supportedStyles" items="${styles}"/>
 


### PR DESCRIPTION
We (@aodn) found that the styles reported in the GetCapabilities documents were not the same as those being reported when you did a GetMetadata request for a layer. This change should mean that both requests should advertise the same supported styles for any given layer.

*NB. I've made this PR from my personal account because the forks and different branches between the @aodn and Unidata versions was too messy.*