### PR TITLE
Handle the creation of DateTime objects from CalendarDate objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>ncwms</artifactId>
   <packaging>jar</packaging>
   <name>ncWMS</name>
-  <version>1.2.tds.4.6.2-SNAPSHOT</version>
+  <version>1.2.tds.4.6.4-SNAPSHOT</version>
   <description>
     ncWMS is an OGC Web Map Service (WMS) for geospatial data that are
     stored in CF-compliant NetCDF files.
@@ -356,7 +356,7 @@
   </build>
 
   <properties>
-    <cdm.version>4.6.1</cdm.version>
+    <cdm.version>4.6.4-SNAPSHOT</cdm.version>
 
     <org.geotoolkit.version>3.21</org.geotoolkit.version>
 

--- a/src/java/ucar/nc2/time/ExposeDateTime.java
+++ b/src/java/ucar/nc2/time/ExposeDateTime.java
@@ -1,0 +1,59 @@
+package ucar.nc2.time;
+/*
+ * Copyright 1998-2015 University Corporation for Atmospheric Research/Unidata
+ *
+ * Portions of this software were developed by the Unidata Program at the
+ * University Corporation for Atmospheric Research.
+ *
+ * Access and use of this software shall impose the following obligations
+ * and understandings on the user. The user is granted the right, without
+ * any fee or cost, to use, copy, modify, alter, enhance and distribute
+ * this software, and any derivative works thereof, and its supporting
+ * documentation for any purpose whatsoever, provided that this entire
+ * notice appears in all copies of the software, derivative works and
+ * supporting documentation.  Further, UCAR requests that the user credit
+ * UCAR/Unidata in any publications that result from the use of this
+ * software or in any product that includes this software. The names UCAR
+ * and/or Unidata, however, may not be used in any advertising or publicity
+ * to endorse or promote any products or commercial entity unless specific
+ * written permission is obtained from UCAR/Unidata. The user also
+ * understands that UCAR/Unidata is not obligated to provide the user with
+ * any support, consulting, training or assistance of any kind with regard
+ * to the use, operation and performance of this software nor to provide
+ * the user with any updates, revisions, new versions or "bug fixes."
+ *
+ * THIS SOFTWARE IS PROVIDED BY UCAR/UNIDATA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL UCAR/UNIDATA BE LIABLE FOR ANY SPECIAL,
+ * INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
+ * FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+ * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
+ * WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+import org.joda.time.DateTime;
+
+/**
+ * Just a static method to expose the package private method getDateTime()
+ * from ucar.nc2.time.CalendarDate.
+ *
+ * Ideally CdmUtils would be re-written to use CalendarDate directly, but
+ * given the move to edal-java in 5.0, this should suffice.
+ *
+ */
+
+public class ExposeDateTime {
+    /**
+     * Gets List of DateTimes representing the timesteps of the given coordinate
+     * system.
+     *
+     * @param cd
+     *            The CalendarDate Object
+     * @return The DateTime object assocaited with the CalendarDate
+     */
+
+    public static DateTime getDateTime(CalendarDate cd) {
+        return cd.getDateTime();
+    }
+
+}

--- a/src/java/uk/ac/rdg/resc/edal/cdm/CdmUtils.java
+++ b/src/java/uk/ac/rdg/resc/edal/cdm/CdmUtils.java
@@ -72,6 +72,7 @@ import ucar.nc2.dt.GridDataset.Gridset;
 import ucar.nc2.dt.GridDatatype;
 import ucar.nc2.ft.FeatureDatasetFactoryManager;
 import ucar.nc2.time.CalendarDate;
+import ucar.nc2.time.ExposeDateTime;
 import ucar.unidata.geoloc.LatLonPoint;
 import ucar.unidata.geoloc.LatLonRect;
 import uk.ac.rdg.resc.edal.coverage.CoverageMetadata;
@@ -365,7 +366,7 @@ public final class CdmUtils
      * system, in an appropriate {@link Chronology}. (Chronologies represent the
      * calendar system.)
      * 
-     * @param coordSys
+     * @param timeAxis
      *            The coordinate system containing the time information
      * @return List of TimestepInfo objects, or an empty list if the coordinate
      *         system has no time axis
@@ -378,7 +379,7 @@ public final class CdmUtils
         // Use the Java NetCDF library's built-in date parsing code
         //for (Date date : timeAxis.getTimeDates())
         for (CalendarDate date : timeAxis.getCalendarDates()  )
-            timesteps.add(new DateTime(date.getMillis(), DateTimeZone.UTC));
+            timesteps.add(ExposeDateTime.getDateTime(date));
         return timesteps;
     }
 


### PR DESCRIPTION
This basically addresses the issue of ncWMS not returning the correct dates for non-standard calendars (see Unidata/thredds#310)
Bump version of ncWMS to 1.2.tds.4.6.4-SNAPSHOT
Expose package private method from CalendarDate getDateTime() to easily integrate into existing ncWMS code.
The idea is to get away from allowing users to access DateTime objects directly, but in this case it's the easiest path forward, especially since we have moved to edal-java in 5.0.