### PR TITLE
Fix handling of missing values

### DIFF
--- a/src/java/uk/ac/rdg/resc/edal/cdm/DataChunk.java
+++ b/src/java/uk/ac/rdg/resc/edal/cdm/DataChunk.java
@@ -118,11 +118,10 @@ class DataChunk
      * @return the data value, or {@link Float#NaN} if this is a missing value
      */
     public float readFloatValue(Index index) {
-        double val = arr.getFloat(index);
-        if (this.needsEnhance) {
-            val = this.var.convertScaleOffsetMissing(val);
-        }
-        if (this.var.isMissing(val)) return Float.NaN;
-        else return (float)val;
+        double val = arr.getDouble(index);
+        if (this.needsEnhance)
+            return (float) this.var.convertScaleOffsetMissing(val);
+        else
+            return (float) val;
     }
 }


### PR DESCRIPTION
Handling of missing values in `DataChunk.readFloatValue` is broken
due to floating precission issues. For the missing and scale
conversion the actual data types are completely ignored, and
the fill value is internally read as double while the data value
is read as float, possibly resulting in a different value.
The later is preserved by the promotion to double
and causes the comparison to fail.
This is an example of this situation:

    int i = -2147483647;
    float f = (float) i;
    double d = (double) i;
    double f2d = (double) f;
    System.out.format("(i) %d = (f) %.5f = (d) %.5f = (f2d) %.5f\n ", i, f, d, f2d);
    // Outputs:
    // (i) -2147483647 = (f) -2147483648.00000 = (d) -2147483647.00000 = (f2d) -2147483648.00000

Fix it by reading the data value as double,
delaying the cast to float to the return statement.