### PR TITLE
Allow reading a timeseries from an existing GridDatatype

### DIFF
--- a/src/java/uk/ac/rdg/resc/edal/cdm/CdmUtils.java
+++ b/src/java/uk/ac/rdg/resc/edal/cdm/CdmUtils.java
@@ -681,6 +681,14 @@ public final class CdmUtils
             throws IOException
     {
         GridDatatype grid = getGridDatatype(nc, varId);
+        return readTimeseries(nc, grid, horizGrid, tIndices, zIndex, xy);
+    }
+
+    public static List<Float> readTimeseries(NetcdfDataset nc, GridDatatype grid,
+            HorizontalGrid horizGrid, List<Integer> tIndices,
+            int zIndex, HorizontalPosition xy)
+            throws IOException
+    {
         GridCoordinates gridCoords = horizGrid.findNearestGridPoint(xy);
         if (gridCoords == null)
         {


### PR DESCRIPTION
Move the heavy part of reading a timeseries from a dataset
to a more specific function receiving an existing `GridDatatype`,
and implement the reading from a dataset using that delegated function.
This is the same approach already used for `readHorizontalPoints`,
and allows to reuse the code for the layer implementation in Thredds
(socib/thredds@timeseries_fast_read).

See Unidata/thredds#439.