### PR TITLE
fix bug with missing values for int variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>ncwms</artifactId>
   <packaging>jar</packaging>
   <name>ncWMS</name>
-  <version>1.2.tds.4.6.8-SNAPSHOT</version>
+  <version>1.2.tds.4.6.11-SNAPSHOT</version>
   <description>
     ncWMS is an OGC Web Map Service (WMS) for geospatial data that are
     stored in CF-compliant NetCDF files.

--- a/src/java/uk/ac/rdg/resc/edal/cdm/DataChunk.java
+++ b/src/java/uk/ac/rdg/resc/edal/cdm/DataChunk.java
@@ -118,10 +118,11 @@ class DataChunk
      * @return the data value, or {@link Float#NaN} if this is a missing value
      */
     public float readFloatValue(Index index) {
-        double val = arr.getDouble(index);
-        if (this.needsEnhance)
-            return (float) this.var.convertScaleOffsetMissing(val);
-        else
-            return (float) val;
+        double val = arr.getFloat(index);
+        if (this.needsEnhance) {
+            val = this.var.convertScaleOffsetMissing(val);
+        }
+        if (this.var.isMissing(val)) return Float.NaN;
+        else return (float)val;
     }
 }


### PR DESCRIPTION
Needed to bring the readFloatValue method of DataChunk inline with ncWMS's recent version in SVN
in order to properly handle missing_values and _FillValues for integer data.

Also bumped pom to 4.6.11-SNAPSHOT (not sure why this was so behind)