### PR TITLE
Fix response already committed error/corruption of response

### DIFF
--- a/src/java/uk/ac/rdg/resc/ncwms/controller/AbstractWmsController.java
+++ b/src/java/uk/ac/rdg/resc/ncwms/controller/AbstractWmsController.java
@@ -31,6 +31,7 @@ import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -98,6 +99,7 @@ import uk.ac.rdg.resc.ncwms.graphics.ColorPalette;
 import uk.ac.rdg.resc.ncwms.graphics.ImageFormat;
 import uk.ac.rdg.resc.ncwms.graphics.ImageProducer;
 import uk.ac.rdg.resc.ncwms.graphics.KmzFormat;
+import uk.ac.rdg.resc.ncwms.servlet.ServletOutputStreamWrapper;
 import uk.ac.rdg.resc.ncwms.usagelog.UsageLogEntry;
 import uk.ac.rdg.resc.ncwms.usagelog.UsageLogger;
 import uk.ac.rdg.resc.ncwms.util.WmsUtils;
@@ -592,8 +594,9 @@ public abstract class AbstractWmsController extends AbstractController {
                     layer.getDataset().getId() + "_" + layer.getId() + ".kmz");
         }
         // Render the images and write to the output stream
+        OutputStream out = new ServletOutputStreamWrapper(httpServletResponse.getOutputStream());
         imageFormat.writeImage(imageProducer.getRenderedFrames(),
-                httpServletResponse.getOutputStream(), layer, tValueStrings,
+                out, layer, tValueStrings,
                 dr.getElevationString(), grid.getExtent(), legend);
 
         return null;

--- a/src/java/uk/ac/rdg/resc/ncwms/servlet/ServletOutputStreamWrapper.java
+++ b/src/java/uk/ac/rdg/resc/ncwms/servlet/ServletOutputStreamWrapper.java
@@ -1,0 +1,66 @@
+package uk.ac.rdg.resc.ncwms.servlet;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+import java.io.IOException;
+
+/**
+ * Prevent writes to the wrapped ServletOutputStream once it has thrown an exception.
+ * This works around an obscure issue with tomcat and ImageFormat.writeImage where
+ * if the ServletOutputStream is passed as the outputstream it will be flushed by
+ * a finalizer at some random time if an exception is thrown
+ * (in our case a ClientAbortException). This can interfere with the processing of subsequent
+ * requests as tomcat reuses the ServletOutputStream.
+ * Wrap a ServletOutputStream with an instance of this class and pass to the ImageFormat.imageWriter
+ * to prevent the finalizer from interfering with the ServletOutputStream after the exception has
+ * already been handled.
+ */
+
+public class ServletOutputStreamWrapper extends ServletOutputStream {
+    private final ServletOutputStream outputStream;
+    private boolean invalidated = false;
+
+    public ServletOutputStreamWrapper(ServletOutputStream outputStream) {
+        this.outputStream = outputStream;
+    }
+
+    @Override
+    public void write(int i) throws IOException {
+        if (invalidated) return;
+
+        try {
+            outputStream.write(i);
+        } catch (IOException ioe) {
+            invalidated = true;
+            throw ioe;
+        }
+    }
+
+    @Override
+    public boolean isReady() {
+        return outputStream.isReady();
+    }
+
+    @Override
+    public void setWriteListener(WriteListener writeListener) {
+        outputStream.setWriteListener(writeListener);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        if (invalidated) return;
+
+        try {
+            outputStream.flush();
+        } catch (IOException ioe) {
+            invalidated = true;
+            throw ioe;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        outputStream.close();
+    }
+
+}


### PR DESCRIPTION
This fixes https://github.com/Unidata/thredds/issues/1052 and other associated issues.

When serving a GetMap request and the client connection is closed prior to completing the response, javax.imageio.stream.MemoryCacheImageInputStream was not being closed properly due to a ClientAbortException being thrown when trying write to and then flush/close the stream (at http://hg.openjdk.java.net/jdk8u/jdk8u/jdk/file/9d617cfd6717/src/share/classes/javax/imageio/ImageIO.java#l1580).  This class has a finalizer inherited from one of its parent classes (http://hg.openjdk.java.net/jdk8u/jdk8u/jdk/file/9d617cfd6717/src/share/classes/javax/imageio/stream/ImageInputStreamImpl.java#l871) which closes the stream if its still open.  Finalizers are invoked some time later by the finalizer thread (essentially a random time later).  Closing  MemoryCacheImageInputStream closes its wrapped output stream (in this case the ServletOutputStream).  Tomcat reuses ServletOutputStream instances and so this output stream may be being used by another request and being flushed/closed inappropriately during that processing.

This is a known issue with these core java classes and tomcat (refer http://mail-archives.apache.org/mod_mbox/tomcat-users/201306.mbox/%3C51B0B101.3060509@christopherschultz.net%3E and https://bugs.java.com/view_bug.do?bug_id=6299405) with the recommended solution included below.

We have been using this code in our production thredds instance now for almost 2 years with no issues and no "Yikes! Response is already committed (Heiko's bug?)" messages in the log.
